### PR TITLE
[Draft] Use array for clUpdateMutableCommandsKHR

### DIFF
--- a/source/cl/examples/MutableDispatchKHR/source/main.cpp
+++ b/source/cl/examples/MutableDispatchKHR/source/main.cpp
@@ -209,16 +209,11 @@ int main(const int argc, const char **argv) {
     // If not executing the first frame
     if (i != 0) {
       // Configure the mutable configuration to update the kernel arguments
-      const cl_mutable_dispatch_arg_khr arg_0{0, sizeof(cl_mem),
-                                              &input_A_buffer};
-      const cl_mutable_dispatch_arg_khr arg_1{1, sizeof(cl_mem),
-                                              &input_B_buffer};
-      const cl_mutable_dispatch_arg_khr arg_2{2, sizeof(cl_mem),
-                                              &output_buffer};
-      const cl_mutable_dispatch_arg_khr args[] = {arg_0, arg_1, arg_2};
-      const cl_mutable_dispatch_config_khr dispatch_config{
-          CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-          nullptr,
+      cl_mutable_dispatch_arg_khr arg_0{0, sizeof(cl_mem), &input_A_buffer};
+      cl_mutable_dispatch_arg_khr arg_1{1, sizeof(cl_mem), &input_B_buffer};
+      cl_mutable_dispatch_arg_khr arg_2{2, sizeof(cl_mem), &output_buffer};
+      cl_mutable_dispatch_arg_khr args[] = {arg_0, arg_1, arg_2};
+      cl_mutable_dispatch_config_khr dispatch_config{
           command_handle,
           3 /* num_args */,
           0 /* num_svm_arg */,
@@ -230,12 +225,14 @@ int main(const int argc, const char **argv) {
           nullptr /* global_work_offset */,
           nullptr /* global_work_size */,
           nullptr /* local_work_size */};
-      const cl_mutable_base_config_khr mutable_config{
-          CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-          &dispatch_config};
 
       // Update the command buffer with the mutable configuration
-      error = clUpdateMutableCommandsKHR(command_buffer, &mutable_config);
+      cl_uint num_configs = 1;
+      cl_command_buffer_update_type_khr config_types[1] = {
+          CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+      const void *configs[1] = {&dispatch_config};
+      error = clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                         config_types, configs);
       CL_CHECK(error);
     }
 

--- a/source/cl/source/extension/include/extension/khr_command_buffer.h
+++ b/source/cl/source/extension/include/extension/khr_command_buffer.h
@@ -463,7 +463,9 @@ struct _cl_command_buffer_khr final : public cl::base<_cl_command_buffer_khr> {
   /// @param[in] mutable_config New configuration for one or more commands
   ///
   /// @return CL_SUCCESS or appropriate OpenCL error code.
-  cl_int updateCommandBuffer(const cl_mutable_base_config_khr &mutable_config);
+  cl_int updateCommandBuffer(
+      cargo::array_view<const cl_mutable_dispatch_config_khr *>
+          &mutable_configs);
 
   /// @brief Verifies whether a queue is compatible with the command-buffer.
   ///

--- a/source/cl/source/extension/source/khr_command_buffer_mutable_dispatch.cpp
+++ b/source/cl/source/extension/source/khr_command_buffer_mutable_dispatch.cpp
@@ -82,10 +82,11 @@ cl_int extension::khr_command_buffer_mutable_dispatch::GetDeviceInfo(
 }
 
 #ifdef OCL_EXTENSION_cl_khr_command_buffer_mutable_dispatch
-CL_API_ENTRY cl_int CL_API_CALL
-clUpdateMutableCommandsKHR(cl_command_buffer_khr command_buffer,
-                           const cl_mutable_base_config_khr *mutable_config) {
-  const tracer::TraceGuard<tracer::OpenCL> guard("clUpdateMutableCommandsKHR");
+CL_API_ENTRY cl_int CL_API_CALL clUpdateMutableCommandsKHR(
+    cl_command_buffer_khr command_buffer, cl_uint num_configs,
+    const cl_command_buffer_update_type_khr *config_types,
+    const void **configs) {
+  tracer::TraceGuard<tracer::OpenCL> guard("clUpdateMutableCommandsKHR");
   OCL_CHECK(!command_buffer, return CL_INVALID_COMMAND_BUFFER_KHR);
   OCL_CHECK(!command_buffer->is_finalized, return CL_INVALID_OPERATION);
 
@@ -102,20 +103,24 @@ clUpdateMutableCommandsKHR(cl_command_buffer_khr command_buffer,
     return CL_INVALID_OPERATION;
   }
 
-  OCL_CHECK(!mutable_config, return CL_INVALID_VALUE);
-  OCL_CHECK(mutable_config->type != CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR,
-            return CL_INVALID_VALUE);
+  OCL_CHECK(config_types && 0 == num_configs, return CL_INVALID_VALUE);
+  OCL_CHECK(!config_types && num_configs, return CL_INVALID_VALUE);
 
-  // Values for next would be defined by implementation of mutable mem commands
-  // layered extension. Later checks assume next is NULL and so the
-  // mutable_dispatch_list field must be set.
-  OCL_CHECK(mutable_config->next, return CL_INVALID_VALUE);
+  OCL_CHECK(configs && 0 == num_configs, return CL_INVALID_VALUE);
+  OCL_CHECK(!configs && num_configs, return CL_INVALID_VALUE);
 
-  OCL_CHECK(!mutable_config->mutable_dispatch_list ||
-                !mutable_config->num_mutable_dispatch,
-            return CL_INVALID_VALUE);
+  for (size_t i = 0; i < num_configs; i++) {
+    if (config_types[i] != CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR) {
+      return CL_INVALID_VALUE;
+    }
+  }
 
-  return command_buffer->updateCommandBuffer(*mutable_config);
+  const cl_mutable_dispatch_config_khr **casted_configs =
+      reinterpret_cast<const cl_mutable_dispatch_config_khr **>(configs);
+  cargo::array_view<const cl_mutable_dispatch_config_khr *>
+      mutable_dispatch_configs(casted_configs, num_configs);
+
+  return command_buffer->updateCommandBuffer(mutable_dispatch_configs);
 }
 
 CL_API_ENTRY cl_int CL_API_CALL clGetMutableCommandInfoKHR(

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/clEnqueueCommandBufferKHRMutability.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/clEnqueueCommandBufferKHRMutability.cpp
@@ -139,24 +139,17 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateOutputBufferOnce) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -207,28 +200,18 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateOutputBufferTwice) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  const cl_mutable_dispatch_arg_khr first_arg{1, sizeof(cl_mem),
-                                              &first_updated_dst_buffer};
-  const cl_mutable_dispatch_config_khr first_dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &first_arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr first_mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-      &first_dispatch_config};
+  cl_mutable_dispatch_arg_khr first_arg{1, sizeof(cl_mem),
+                                        &first_updated_dst_buffer};
+  cl_mutable_dispatch_config_khr first_dispatch_config{
+      command_handle, 1,       0,       0,       0,      &first_arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
 
-  EXPECT_SUCCESS(
-      clUpdateMutableCommandsKHR(command_buffer, &first_mutable_config));
+  cl_uint first_num_configs = 1;
+  cl_command_buffer_update_type_khr first_config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *first_configs[1] = {&first_dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, first_num_configs,
+                                            first_config_types, first_configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -243,27 +226,17 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateOutputBufferTwice) {
   EXPECT_EQ(input_data, first_updated_output_data);
 
   // Enqueue the command buffer again updating the output buffer a second time.
-  const cl_mutable_dispatch_arg_khr second_arg{1, sizeof(cl_mem),
-                                               &second_updated_dst_buffer};
-  const cl_mutable_dispatch_config_khr second_dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &second_arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr second_mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-      &second_dispatch_config};
-  EXPECT_SUCCESS(
-      clUpdateMutableCommandsKHR(command_buffer, &second_mutable_config));
+  cl_mutable_dispatch_arg_khr second_arg{1, sizeof(cl_mem),
+                                         &second_updated_dst_buffer};
+  cl_mutable_dispatch_config_khr second_dispatch_config{
+      command_handle, 1,       0,       0,       0,      &second_arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint second_num_configs = 1;
+  cl_command_buffer_update_type_khr second_config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *second_configs[1] = {&second_dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(
+      command_buffer, second_num_configs, second_config_types, second_configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -318,24 +291,16 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateInputBufferOnce) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the input buffer.
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &updated_src_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &updated_src_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -400,27 +365,17 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateInputBufferTwice) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the input buffer.
-  const cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_mem),
-                                              &first_updated_src_buffer};
-  const cl_mutable_dispatch_config_khr first_dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &first_arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr first_mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-      &first_dispatch_config};
-  EXPECT_SUCCESS(
-      clUpdateMutableCommandsKHR(command_buffer, &first_mutable_config));
+  cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_mem),
+                                        &first_updated_src_buffer};
+  cl_mutable_dispatch_config_khr first_dispatch_config{
+      command_handle, 1,       0,       0,       0,      &first_arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint first_num_configs = 1;
+  cl_command_buffer_update_type_khr first_config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *first_configs[1] = {&first_dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, first_num_configs,
+                                            first_config_types, first_configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -435,27 +390,17 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateInputBufferTwice) {
   EXPECT_EQ(first_updated_input_data, output_data);
 
   // Enqueue the command buffer a second time updating the input bufer again.
-  const cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_mem),
-                                               &second_updated_src_buffer};
-  const cl_mutable_dispatch_config_khr second_dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &second_arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr second_mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-      &second_dispatch_config};
-  EXPECT_SUCCESS(
-      clUpdateMutableCommandsKHR(command_buffer, &second_mutable_config));
+  cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_mem),
+                                         &second_updated_src_buffer};
+  cl_mutable_dispatch_config_khr second_dispatch_config{
+      command_handle, 1,       0,       0,       0,      &second_arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint second_num_configs = 1;
+  cl_command_buffer_update_type_khr second_config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *second_configs[1] = {&second_dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(
+      command_buffer, second_num_configs, second_config_types, second_configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -521,23 +466,15 @@ TEST_F(CommandBufferMutableBufferArgTest,
   const cl_mutable_dispatch_arg_khr arg_2{1, sizeof(cl_mem),
                                           &updated_dst_buffer};
   cl_mutable_dispatch_arg_khr args[] = {arg_1, arg_2};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      2,
-      0,
-      0,
-      0,
-      args,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 2,       0,       0,       0,      args,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -598,43 +535,21 @@ TEST_F(CommandBufferMutableBufferArgTest,
 
   // Now try and enqueue the command buffer updating the input and output
   // buffers.
-  const cl_mutable_dispatch_arg_khr arg_1{0, sizeof(cl_mem),
-                                          &updated_src_buffer};
-  const cl_mutable_dispatch_arg_khr arg_2{1, sizeof(cl_mem),
-                                          &updated_dst_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config_1{
+  cl_mutable_dispatch_arg_khr arg_1{0, sizeof(cl_mem), &updated_src_buffer};
+  cl_mutable_dispatch_arg_khr arg_2{1, sizeof(cl_mem), &updated_dst_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config_1{
+      command_handle, 1,       0,       0,       0,      &arg_1,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_mutable_dispatch_config_khr dispatch_config_2{
+      command_handle, 1,       0,       0,       0,      &arg_2,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 2;
+  cl_command_buffer_update_type_khr config_types[2] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg_1,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_dispatch_config_khr dispatch_config_2{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg_2,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  cl_mutable_dispatch_config_khr dispatch_configs[] = {dispatch_config_1,
-                                                       dispatch_config_2};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 2, dispatch_configs};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[2] = {&dispatch_config_1, &dispatch_config_2};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -693,24 +608,16 @@ TEST_F(CommandBufferMutableBufferArgTest, UpdateToBiggerBufferSize) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -762,24 +669,16 @@ TEST_F(CommandBufferMutableBufferArgTest, CheckUpdatePersists) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -860,24 +759,16 @@ TEST_F(CommandBufferMutableBufferArgTest, FillThenNDRange) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -938,24 +829,16 @@ TEST_F(CommandBufferMutableBufferArgTest, NDRangeThenFill) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -1019,24 +902,16 @@ TEST_F(CommandBufferMutableBufferArgTest, FillTwiceThenNDRange) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -1099,24 +974,16 @@ TEST_F(CommandBufferMutableBufferArgTest, CopyBufferThenNDRange) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -1181,24 +1048,16 @@ TEST_F(CommandBufferMutableBufferArgTest, CopyBufferRectThenNDRange) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -1270,24 +1129,16 @@ TEST_F(CommandBufferMutableBufferArgTest, RegularNDRangeThenMutableNDRange) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the output buffer.
-  const cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{1, sizeof(cl_mem), &updated_dst_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -1424,24 +1275,16 @@ TEST_F(CommandBufferMultiMutableBufferArgTest, UpdateSingleDispatch) {
 
   // Now try and enqueue the command buffer updating the output buffer of the
   // first nd range.
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &updated_src_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &updated_src_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -1512,46 +1355,33 @@ TEST_F(CommandBufferMultiMutableBufferArgTest, UpdateMultipleDispatches) {
 
   // Now try and enqueue the command buffer updating the input buffer of both
   // nd ranges.
-  const cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_mem),
-                                              &first_updated_src_buffer};
-  const cl_mutable_dispatch_config_khr first_dispatch_config{
+  cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_mem),
+                                        &first_updated_src_buffer};
+  cl_mutable_dispatch_config_khr first_dispatch_config{
+      command_handle, 1,       0,       0,       0,      &first_arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+
+  cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_mem),
+                                         &second_updated_src_buffer};
+  cl_mutable_dispatch_config_khr second_dispatch_config{second_command_handle,
+                                                        1,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        &second_arg,
+                                                        nullptr,
+                                                        nullptr,
+                                                        nullptr,
+                                                        nullptr,
+                                                        nullptr};
+
+  cl_uint num_configs = 2;
+  cl_command_buffer_update_type_khr config_types[2] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &first_arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-
-  const cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_mem),
-                                               &second_updated_src_buffer};
-  const cl_mutable_dispatch_config_khr second_dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      second_command_handle,
-      1,
-      0,
-      0,
-      0,
-      &second_arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-
-  cl_mutable_dispatch_config_khr dispatch_configs[]{first_dispatch_config,
-                                                    second_dispatch_config};
-
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 2, dispatch_configs};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[2] = {&first_dispatch_config, &second_dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -1669,24 +1499,16 @@ TEST_F(MutableDispatchTest, UpdateConstantBuffer) {
   EXPECT_EQ(input_data, output_data);
 
   // Now try and enqueue the command buffer updating the input buffer.
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &updated_src_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &updated_src_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -1784,24 +1606,16 @@ TEST_F(CommandBufferMutableLocalBufferArgTest, UpdateOnce) {
   EXPECT_SUCCESS(clFinish(command_queue));
 
   // Update the local buffer size.
-  const cl_mutable_dispatch_arg_khr arg{0, 32, nullptr};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, 32, nullptr};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 }
@@ -1815,24 +1629,16 @@ TEST_F(CommandBufferMutableLocalBufferArgTest, UpdateTwice) {
   EXPECT_SUCCESS(clFinish(command_queue));
 
   // Update the local buffer size.
-  const cl_mutable_dispatch_arg_khr arg{0, 32, nullptr};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, 32, nullptr};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -1840,25 +1646,16 @@ TEST_F(CommandBufferMutableLocalBufferArgTest, UpdateTwice) {
   EXPECT_SUCCESS(clFinish(command_queue));
 
   // Update the local buffer size a second time.
-  const cl_mutable_dispatch_arg_khr arg_2{0, 32, nullptr};
-  const cl_mutable_dispatch_config_khr dispatch_config_2{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg_2,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config_2{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-      &dispatch_config_2};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config_2));
+  cl_mutable_dispatch_arg_khr arg_2{0, 32, nullptr};
+  cl_mutable_dispatch_config_khr dispatch_config_2{
+      command_handle, 1,       0,       0,       0,      &arg_2,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs_2 = 1;
+  cl_command_buffer_update_type_khr config_types_2[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs_2[1] = {&dispatch_config_2};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs_2,
+                                            config_types_2, configs_2));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 }
@@ -1988,24 +1785,16 @@ TEST_F(DISABLED_CommandBufferMutableNullArgTest,
   EXPECT_EQ(output_data, std::vector<cl_int>(global_size, 0x0));
 
   // Update the input to null and enqueue a second time.
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), nullptr};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), nullptr};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -2053,24 +1842,16 @@ TEST_F(DISABLED_CommandBufferMutableNullArgTest,
 
   // Update the input to pointer to null.
   const cl_int *null = nullptr;
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &null};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &null};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -2116,24 +1897,16 @@ TEST_F(DISABLED_CommandBufferMutableNullArgTest,
   EXPECT_EQ(output_data, std::vector<cl_int>(global_size, 0x1));
 
   // Update the input to null.
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &src_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &src_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -2180,24 +1953,16 @@ TEST_F(DISABLED_CommandBufferMutableNullArgTest,
   EXPECT_EQ(output_data, std::vector<cl_int>(global_size, 0x1));
 
   // Update the input to null.
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &src_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), &src_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -2241,24 +2006,16 @@ TEST_F(DISABLED_CommandBufferMutableNullArgTest, CheckUpdatePersists) {
   EXPECT_EQ(output_data, std::vector<cl_int>(global_size, 0x0));
 
   // Update the input to null and enqueue a second time.
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), nullptr};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), nullptr};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -2383,24 +2140,16 @@ TEST_F(DISABLED_CommandBufferMultiMutableNullArgTest, UpdateSingleDispatch) {
   EXPECT_EQ(second_output_data, std::vector<cl_int>(global_size, 0x0));
 
   // Update the input of the first nd range to null and enqueue a second time.
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), nullptr};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_mem), nullptr};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -2440,44 +2189,31 @@ TEST_F(DISABLED_CommandBufferMultiMutableNullArgTest,
   EXPECT_EQ(second_output_data, std::vector<cl_int>(global_size, 0x0));
 
   // Update the input of both nd ranges to null and enqueue a second time.
-  const cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_mem), nullptr};
-  const cl_mutable_dispatch_config_khr first_dispatch_config{
+  cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_mem), nullptr};
+  cl_mutable_dispatch_config_khr first_dispatch_config{
+      command_handle, 1,       0,       0,       0,      &first_arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+
+  cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_mem), nullptr};
+  cl_mutable_dispatch_config_khr second_dispatch_config{second_command_handle,
+                                                        1,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        &second_arg,
+                                                        nullptr,
+                                                        nullptr,
+                                                        nullptr,
+                                                        nullptr,
+                                                        nullptr};
+
+  cl_uint num_configs = 2;
+  cl_command_buffer_update_type_khr config_types[2] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &first_arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-
-  const cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_mem), nullptr};
-  const cl_mutable_dispatch_config_khr second_dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      second_command_handle,
-      1,
-      0,
-      0,
-      0,
-      &second_arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-
-  cl_mutable_dispatch_config_khr dispatch_configs[]{first_dispatch_config,
-                                                    second_dispatch_config};
-
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 2, dispatch_configs};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[2] = {&first_dispatch_config, &second_dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -2588,26 +2324,17 @@ TEST_F(CommandBufferMutablePODArgTest, InvalidArgSize) {
   // Now try and enqueue the command buffer updating the input value.
   const auto updated_input_value =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int4),
-                                        &updated_input_value};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_EQ_ERRCODE(CL_INVALID_ARG_SIZE, clUpdateMutableCommandsKHR(
-                                             command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int4), &updated_input_value};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_EQ_ERRCODE(CL_INVALID_ARG_SIZE,
+                    clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                               config_types, configs));
 }
 
 TEST_F(CommandBufferMutablePODArgTest, UpdateInputOnce) {
@@ -2633,25 +2360,16 @@ TEST_F(CommandBufferMutablePODArgTest, UpdateInputOnce) {
   // Now try and enqueue the command buffer updating the input value.
   const auto updated_input_value =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int),
-                                        &updated_input_value};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int), &updated_input_value};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -2687,27 +2405,17 @@ TEST_F(CommandBufferMutablePODArgTest, UpdateInputTwice) {
   // Now try and enqueue the command buffer updating the input value.
   const auto first_updated_input_value =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
-  const cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_int),
-                                              &first_updated_input_value};
-  const cl_mutable_dispatch_config_khr first_dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &first_arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr first_mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-      &first_dispatch_config};
-  EXPECT_SUCCESS(
-      clUpdateMutableCommandsKHR(command_buffer, &first_mutable_config));
+  cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_int),
+                                        &first_updated_input_value};
+  cl_mutable_dispatch_config_khr first_dispatch_config{
+      command_handle, 1,       0,       0,       0,      &first_arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint first_num_configs = 1;
+  cl_command_buffer_update_type_khr first_config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *first_configs[1] = {&first_dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, first_num_configs,
+                                            first_config_types, first_configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -2727,27 +2435,17 @@ TEST_F(CommandBufferMutablePODArgTest, UpdateInputTwice) {
   // time.
   const auto second_updated_input_value =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
-  const cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_int),
-                                               &second_updated_input_value};
-  const cl_mutable_dispatch_config_khr second_dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &second_arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr second_mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-      &second_dispatch_config};
-  EXPECT_SUCCESS(
-      clUpdateMutableCommandsKHR(command_buffer, &second_mutable_config));
+  cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_int),
+                                         &second_updated_input_value};
+  cl_mutable_dispatch_config_khr second_dispatch_config{
+      command_handle, 1,       0,       0,       0,      &second_arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint second_num_configs = 1;
+  cl_command_buffer_update_type_khr second_config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *second_configs[1] = {&second_dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(
+      command_buffer, second_num_configs, second_config_types, second_configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -2784,25 +2482,16 @@ TEST_F(CommandBufferMutablePODArgTest, CheckUpdatePersists) {
   // Now try and enqueue the command buffer updating the input value.
   const auto updated_input_value =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int),
-                                        &updated_input_value};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int), &updated_input_value};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -2926,25 +2615,16 @@ TEST_F(CommandBufferMultiMutablePODArgTest, UpdateSingleDispatch) {
   // first nd range only.
   const auto updated_input_value =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int),
-                                        &updated_input_value};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int), &updated_input_value};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -2997,47 +2677,36 @@ TEST_F(CommandBufferMultiMutablePODArgTest, UpdateMultipleDispatches) {
   // ranges.
   const auto first_updated_input_value =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
-  const cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_int),
-                                              &first_updated_input_value};
-  const cl_mutable_dispatch_config_khr first_dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &first_arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
+  cl_mutable_dispatch_arg_khr first_arg{0, sizeof(cl_int),
+                                        &first_updated_input_value};
+  cl_mutable_dispatch_config_khr first_dispatch_config{
+      command_handle, 1,       0,       0,       0,      &first_arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
 
   const auto second_updated_input_value =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
-  const cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_int),
-                                               &second_updated_input_value};
-  const cl_mutable_dispatch_config_khr second_dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      second_command_handle,
-      1,
-      0,
-      0,
-      0,
-      &second_arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  cl_mutable_dispatch_config_khr mutable_configs[]{first_dispatch_config,
-                                                   second_dispatch_config};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 2, mutable_configs};
+  cl_mutable_dispatch_arg_khr second_arg{0, sizeof(cl_int),
+                                         &second_updated_input_value};
+  cl_mutable_dispatch_config_khr second_dispatch_config{second_command_handle,
+                                                        1,
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        &second_arg,
+                                                        nullptr,
+                                                        nullptr,
+                                                        nullptr,
+                                                        nullptr,
+                                                        nullptr};
 
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_uint num_configs = 2;
+  cl_command_buffer_update_type_khr config_types[2] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+
+  const void *configs[2] = {&first_dispatch_config, &second_dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
 
@@ -3185,23 +2854,15 @@ TEST_F(CommandBufferMutablePODMultiArgTest,
   const cl_mutable_dispatch_arg_khr arg_2{1, sizeof(cl_int),
                                           &updated_input_y_data};
   cl_mutable_dispatch_arg_khr args[] = {arg_1, arg_2};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      2,
-      0,
-      0,
-      0,
-      args,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 2,       0,       0,       0,      args,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
   // Check the results.
@@ -3240,43 +2901,21 @@ TEST_F(CommandBufferMutablePODMultiArgTest,
   cl_int updated_input_y_data =
       ucl::Environment::instance->GetInputGenerator().GenerateInt<cl_int>();
 
-  const cl_mutable_dispatch_arg_khr arg_1{0, sizeof(cl_int),
-                                          &updated_input_x_data};
-  const cl_mutable_dispatch_arg_khr arg_2{1, sizeof(cl_int),
-                                          &updated_input_y_data};
-  const cl_mutable_dispatch_config_khr dispatch_config_1{
+  cl_mutable_dispatch_arg_khr arg_1{0, sizeof(cl_int), &updated_input_x_data};
+  cl_mutable_dispatch_arg_khr arg_2{1, sizeof(cl_int), &updated_input_y_data};
+  cl_mutable_dispatch_config_khr dispatch_config_1{
+      command_handle, 1,       0,       0,       0,      &arg_1,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_mutable_dispatch_config_khr dispatch_config_2{
+      command_handle, 1,       0,       0,       0,      &arg_2,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 2;
+  cl_command_buffer_update_type_khr config_types[2] = {
       CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg_1,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_dispatch_config_khr dispatch_config_2{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg_2,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  cl_mutable_dispatch_config_khr dispatch_configs[]{dispatch_config_1,
-                                                    dispatch_config_2};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 2, dispatch_configs};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[2] = {&dispatch_config_1, &dispatch_config_2};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
   // Check the results.
@@ -3379,24 +3018,16 @@ TEST_F(CommandBufferMutableStructArgTest, UpdateInputOnce) {
 
   // Now try and enqueue the command buffer updating the output buffer.
   const test_struct second_value{99, 42.0f, 'j'};
-  const cl_mutable_dispatch_arg_khr arg{0, sizeof(test_struct), &second_value};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      1,
-      0,
-      0,
-      0,
-      &arg,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, sizeof(test_struct), &second_value};
+  cl_mutable_dispatch_config_khr dispatch_config{
+      command_handle, 1,       0,       0,       0,      &arg,
+      nullptr,        nullptr, nullptr, nullptr, nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
   EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                            nullptr, nullptr));
   // Check the results.

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/thread_safety.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/thread_safety.cpp
@@ -107,27 +107,18 @@ TEST_F(MutableDispatchThreadSafetyTest, UpdateInParallel) {
   auto update_input_value_and_enqueue = [&](size_t id) {
     const cl_int updated_input_value = id;
     // Create a mutable config.
-    const cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int),
-                                          &updated_input_value};
-    const cl_mutable_dispatch_config_khr dispatch_config{
-        CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-        nullptr,
-        command_handle,
-        1,
-        0,
-        0,
-        0,
-        &arg,
-        nullptr,
-        nullptr,
-        nullptr,
-        nullptr,
-        nullptr};
-    const cl_mutable_base_config_khr mutable_config{
-        CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1,
-        &dispatch_config};
+    cl_mutable_dispatch_arg_khr arg{0, sizeof(cl_int), &updated_input_value};
+    cl_mutable_dispatch_config_khr dispatch_config{
+        command_handle, 1,       0,       0,       0,      &arg,
+        nullptr,        nullptr, nullptr, nullptr, nullptr};
     // Update the nd range.
-    EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+    cl_uint num_configs = 1;
+    cl_command_buffer_update_type_khr config_types[1] = {
+        CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+    const void *configs[1] = {&dispatch_config};
+
+    EXPECT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                              config_types, configs));
     EXPECT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
                                              nullptr, nullptr));
   };

--- a/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/usm_arg_update.cpp
+++ b/source/cl/test/UnitCL/source/cl_khr_command_buffer_mutable_dispatch/usm_arg_update.cpp
@@ -138,30 +138,28 @@ TEST_F(MutableDispatchUSMTest, InvalidArgList) {
 
   ASSERT_SUCCESS(clFinalizeCommandBufferKHR(command_buffer));
 
-  cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      0,
-      1 /* num_svm_args */,
-      0,
-      0,
-      nullptr,
-      nullptr /* arg_svm_list */,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
+  cl_mutable_dispatch_config_khr dispatch_config{command_handle,
+                                                 0,
+                                                 1 /* num_svm_args */,
+                                                 0,
+                                                 0,
+                                                 nullptr,
+                                                 nullptr /* arg_svm_list */,
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr};
 
-  ASSERT_EQ_ERRCODE(CL_INVALID_VALUE, clUpdateMutableCommandsKHR(
-                                          command_buffer, &mutable_config));
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  ASSERT_EQ_ERRCODE(CL_INVALID_VALUE,
+                    clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                               config_types, configs));
 
-  const cl_mutable_dispatch_arg_khr arg{0, 0, device_ptrs[1]};
-  dispatch_config = {CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-                     nullptr,
-                     command_handle,
+  cl_mutable_dispatch_arg_khr arg{0, 0, device_ptrs[1]};
+  dispatch_config = {command_handle,
                      0,
                      0 /* num_svm_args */,
                      0,
@@ -173,8 +171,9 @@ TEST_F(MutableDispatchUSMTest, InvalidArgList) {
                      nullptr,
                      nullptr};
 
-  ASSERT_EQ_ERRCODE(CL_INVALID_VALUE, clUpdateMutableCommandsKHR(
-                                          command_buffer, &mutable_config));
+  ASSERT_EQ_ERRCODE(CL_INVALID_VALUE,
+                    clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                               config_types, configs));
 }
 
 // Test clSetKernelMemPointerINTEL error code for CL_INVALID_ARG_INDEX if
@@ -191,26 +190,26 @@ TEST_F(MutableDispatchUSMTest, InvalidArgIndex) {
 
   ASSERT_SUCCESS(clFinalizeCommandBufferKHR(command_buffer));
 
-  const cl_mutable_dispatch_arg_khr arg{2 /* arg index */, 0, device_ptrs[1]};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      0,
-      1 /* num_svm_args */,
-      0,
-      0,
-      nullptr,
-      &arg /* arg_svm_list */,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
+  cl_mutable_dispatch_arg_khr arg{2 /* arg index */, 0, device_ptrs[1]};
+  cl_mutable_dispatch_config_khr dispatch_config{command_handle,
+                                                 0,
+                                                 1 /* num_svm_args */,
+                                                 0,
+                                                 0,
+                                                 nullptr,
+                                                 &arg /* arg_svm_list */,
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr};
 
-  ASSERT_EQ_ERRCODE(CL_INVALID_ARG_INDEX, clUpdateMutableCommandsKHR(
-                                              command_buffer, &mutable_config));
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  ASSERT_EQ_ERRCODE(CL_INVALID_ARG_INDEX,
+                    clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                               config_types, configs));
 }
 
 TEST_F(MutableDispatchUSMTest, InvalidArgValue) {
@@ -225,29 +224,30 @@ TEST_F(MutableDispatchUSMTest, InvalidArgValue) {
 
   ASSERT_SUCCESS(clFinalizeCommandBufferKHR(command_buffer));
 
-  const cl_mutable_dispatch_arg_khr arg{0, 0, &out_buffer};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      0,
-      1 /* num_svm_args */,
-      0,
-      0,
-      nullptr,
-      &arg /* arg_svm_list */,
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
+  cl_mutable_dispatch_arg_khr arg{0, 0, &out_buffer};
+  cl_mutable_dispatch_config_khr dispatch_config{command_handle,
+                                                 0,
+                                                 1 /* num_svm_args */,
+                                                 0,
+                                                 0,
+                                                 nullptr,
+                                                 &arg /* arg_svm_list */,
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr};
 
   // The interaction between cl_intel_unified_shared_memory and
   // cl_khr_command_buffer_mutable_dispatch is not specified but we assume that
   // if clSetKernelArgMemPointerINTEL would not report invalid values, neither
   // will clUpdateMutableCommandsKHR.
-  ASSERT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  ASSERT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
 }
 
 // Tests for updating USM arguments to a command-buffer kernel command are
@@ -319,24 +319,24 @@ TEST_P(MutableDispatchUpdateUSMArgs, NoOffset) {
   ASSERT_EQ(inputA, output);
 
   // Update both the input and argument to second device USM allocation
-  const cl_mutable_dispatch_arg_khr arg{0, 0, ptrB};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      0,
-      1, /* num_svm_args */
-      0,
-      0,
-      nullptr,
-      &arg, /* arg_svm_list */
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  ASSERT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, 0, ptrB};
+  cl_mutable_dispatch_config_khr dispatch_config{command_handle,
+                                                 0,
+                                                 1, /* num_svm_args */
+                                                 0,
+                                                 0,
+                                                 nullptr,
+                                                 &arg, /* arg_svm_list */
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  ASSERT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
 
   // Enqueue the command buffer.
   ASSERT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
@@ -409,24 +409,24 @@ TEST_P(MutableDispatchUpdateUSMArgs, Offset) {
   ASSERT_EQ(inputA, output);
 
   // Update both the input and argument to second device USM allocation
-  const cl_mutable_dispatch_arg_khr arg{0, 0, offset_ptrB};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      0,
-      1, /* num_svm_args */
-      0,
-      0,
-      nullptr,
-      &arg, /* arg_svm_list */
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  ASSERT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, 0, offset_ptrB};
+  cl_mutable_dispatch_config_khr dispatch_config{command_handle,
+                                                 0,
+                                                 1, /* num_svm_args */
+                                                 0,
+                                                 0,
+                                                 nullptr,
+                                                 &arg, /* arg_svm_list */
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  ASSERT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
 
   // Enqueue the command buffer.
   ASSERT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,
@@ -534,24 +534,24 @@ TEST_F(MutableDispatchUSMTest, DISABLED_UpdateBlockingFree) {
   ASSERT_EQ(inputA, output);
 
   // Update both the input and argument to second device USM allocation
-  const cl_mutable_dispatch_arg_khr arg{0, 0, usm_ptrB};
-  const cl_mutable_dispatch_config_khr dispatch_config{
-      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR,
-      nullptr,
-      command_handle,
-      0,
-      1, /* num_svm_args */
-      0,
-      0,
-      nullptr,
-      &arg, /* arg_svm_list */
-      nullptr,
-      nullptr,
-      nullptr,
-      nullptr};
-  const cl_mutable_base_config_khr mutable_config{
-      CL_STRUCTURE_TYPE_MUTABLE_BASE_CONFIG_KHR, nullptr, 1, &dispatch_config};
-  ASSERT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, &mutable_config));
+  cl_mutable_dispatch_arg_khr arg{0, 0, usm_ptrB};
+  cl_mutable_dispatch_config_khr dispatch_config{command_handle,
+                                                 0,
+                                                 1, /* num_svm_args */
+                                                 0,
+                                                 0,
+                                                 nullptr,
+                                                 &arg, /* arg_svm_list */
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr,
+                                                 nullptr};
+  cl_uint num_configs = 1;
+  cl_command_buffer_update_type_khr config_types[1] = {
+      CL_STRUCTURE_TYPE_MUTABLE_DISPATCH_CONFIG_KHR};
+  const void *configs[1] = {&dispatch_config};
+  ASSERT_SUCCESS(clUpdateMutableCommandsKHR(command_buffer, num_configs,
+                                            config_types, configs));
 
   // Enqueue the command buffer.
   ASSERT_SUCCESS(clEnqueueCommandBufferKHR(0, nullptr, command_buffer, 0,


### PR DESCRIPTION
Draft implementation change to prototype specification changes proposed in https://github.com/KhronosGroup/OpenCL-Docs/issues/1041

Uses OpenCL-Docs and OpenCL-Header changes from
* https://github.com/KhronosGroup/OpenCL-Docs/pull/1045
* https://github.com/KhronosGroup/OpenCL-Headers/pull/245

PR is not in a mergable state, and needs cleaned up before submitting to upstream OCK.